### PR TITLE
Updated to use angular@1.5.7, set package.json license/repository

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,12 +20,12 @@
     "amcharts": "~3.15.2",
     "amcharts-stock": "*",
     "ammap": "~3.14.5",
-    "angular": "~1.4.8",
-    "angular-route": "~1.4.6",
+    "angular": "~1.5.7",
+    "angular-route": "~1.5.7",
     "angular-slimscroll": "~1.1.5",
     "angular-smart-table": "~2.1.3",
     "angular-toastr": "~1.7.0",
-    "angular-touch": "~1.4.6",
+    "angular-touch": "~1.5.7",
     "angular-ui-sortable": "~0.13.4",
     "animate.css": "~3.4.0",
     "bootstrap": "~3.3.5",
@@ -47,10 +47,10 @@
     "angular-chart.js": "~0.8.8",
     "angular-chartist.js": "~3.3.12",
     "chartist": "0.9.5",
-    "angular-morris-chart": "~1.1.0",
+    "angular-morris-chart": "~1.2.0",
     "ionrangeslider": "~2.1.2",
     "angular-bootstrap": "~1.3.3",
-    "angular-animate": "~1.4.8",
+    "angular-animate": "~1.5.7",
     "textAngular": "~1.4.6",
     "angular-xeditable": "~0.1.9",
     "ng-js-tree": "~0.0.7"
@@ -95,5 +95,8 @@
         "fonts/fontawesome-webfont.woff2"
       ]
     }
+  },
+  "resolutions": {
+    "angular": "~1.5.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,5 +44,10 @@
   },
   "scripts": {
     "postinstall": "bower install"
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/akveo/blur-admin"
+  },
+  "license" : "MIT"
 }


### PR DESCRIPTION
Just some very _minor_ changes:

npm install was showing

``` bash
npm WARN blur_admin@1.2.0 No repository field.
npm WARN blur_admin@1.2.0 No license field.
```

bower install was showing

``` bash
Unable to find a suitable version for angular, please choose one by typing one of the numbers below:
    1) angular#1.3.x which resolved to 1.3.20 and is required by angular-morris-chart#1.1.0
    2) angular#1.4.12 which resolved to 1.4.12 and is required by angular-animate#1.4.12, angular-route#1.4.12, angular-touch#1.4.12
    3) angular#~1.x which resolved to 1.4.12 and is required by angular-progress-button-styles#0.1.0, angular-xeditable#0.1.12
    4) angular#>=1.3.x which resolved to 1.4.12 and is required by textAngular#1.4.6
    5) angular#^1.0.0 which resolved to 1.4.12 and is required by angular-smart-table#2.1.8
    6) angular#1.4.x which resolved to 1.4.12 and is required by angular-chart.js#0.8.9
    7) angular#~1.4.8 which resolved to 1.4.12 and is required by blur-admin
    8) angular#~1.4 which resolved to 1.4.12 and is required by ng-js-tree#0.0.8
    9) angular#>=1.2.x which resolved to 1.4.12 and is required by angular-ui-sortable#0.13.4
    10) angular#>=1.3.0 which resolved to 1.4.12 and is required by angular-toastr#1.7.0
    11) angular#^1.2.28 which resolved to 1.4.12 and is required by angular-chartist.js#3.3.13
    12) angular#>=1.4.0 which resolved to 1.5.7 and is required by angular-bootstrap#1.3.3
    13) angular#^1.0.8 which resolved to 1.5.7 and is required by angular-ui-router#0.2.18
```

Seems that we're already mixing angular dependencies anyways so why not just use the latest stable at 1.5.7?

I did a quick smoke test with this and everything still works.
