### PR TITLE
fix  eslint config error when run gulp in win10 or does not assign any custom eslint config.

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,5 +44,10 @@
   },
   "scripts": {
     "postinstall": "bower install"
+  },
+  "eslintConfig": {
+    "globals": {
+      "window": true
+    }
   }
 }


### PR DESCRIPTION
fix  eslint config error when run `gulp scripts` in win10 or does not assign any custom eslint config.(_mac os work fine_)

> **for example: if you clone blur-admin run in visual studio (_restore all package_) or any way run `gulp scripts`   will reappear this error. please review and verify this error.**_

> blur-admin\node_modules\.1.10.3@eslint\lib\config\config-file.js:332
            throw e;
            ^

> Error: Cannot read config package: eslint-config-defaults/configurations/eslint
> Error: Cannot find module 'eslint-config-defaults/configurations/eslint'