### PR TITLE
Change state of switch button programmatically

### DIFF
--- a/src/app/pages/form/inputs/widgets/switch/switch.directive.js
+++ b/src/app/pages/form/inputs/widgets/switch/switch.directive.js
@@ -30,7 +30,9 @@
             scope.ngModel = state;
             scope.$apply();
           });
-
+          scope.$watch('ngModel', function(newVal, oldVal) {
+            input.bootstrapSwitch('state', newVal, true);
+          });
         });
       }
     };


### PR DESCRIPTION
If you try to change the switch ngModel after loading the DOM, the button state (on or off) is not changed. (E.g. Loading server data).