### PR TITLE
baSidebar fixedHrefs with blank calls as root node

### DIFF
--- a/src/app/pages/pages.module.js
+++ b/src/app/pages/pages.module.js
@@ -57,6 +57,12 @@
         }]
       }]
     });
+
+    baSidebarServiceProvider.addStaticItem({
+      title: 'blank call sample',
+      fixedHref: 'reg.html',
+      blank: true
+    });
   }
 
 })();

--- a/src/app/theme/components/baSidebar/ba-sidebar.html
+++ b/src/app/theme/components/baSidebar/ba-sidebar.html
@@ -5,7 +5,7 @@
         ng-class="::{'with-sub-menu': item.subMenu}" ui-sref-active="selected"
         ba-sidebar-toggling-item="item">
 
-      <a ng-mouseenter="hoverItem($event, item)" ui-state="item.stateRef || ''" ng-href="{{::(item.fixedHref ? item.fixedHref: '')}}" ng-if="::!item.subMenu" class="al-sidebar-list-link">
+      <a ng-mouseenter="hoverItem($event, item)" ui-state="item.stateRef || ''" ng-href="{{::(item.fixedHref ? item.fixedHref: '')}}" ng-if="::!item.subMenu" class="al-sidebar-list-link" target="{{::(item.blank ? '_blank' : '_self')}}">
         <i class="{{ ::item.icon }}"></i><span>{{ ::item.title }}</span>
       </a>
 


### PR DESCRIPTION
there was an issue, where fixedHref calls outside of a submenu wouldn't work.
I fixed that issue and added a sample entry to the sidebar.