### PR TITLE
Add to baSwitcher on-change handler

### DIFF
--- a/src/app/theme/inputs/baSwitcher/baSwitcher.html
+++ b/src/app/theme/inputs/baSwitcher/baSwitcher.html
@@ -1,5 +1,5 @@
 <label class="switcher-container">
-  <input type="checkbox" ng-model="switcherValue">
+  <input type="checkbox" ng-model="switcherValue" ng-change="switcherChange(switcherData, switcherValue)">
   <div class="switcher" ng-class="::switcherStyle">
     <div class="handle-container">
       <span class="handle handle-on">ON</span>

--- a/src/app/theme/inputs/baSwitcher/baSwitcher.js
+++ b/src/app/theme/inputs/baSwitcher/baSwitcher.js
@@ -14,7 +14,9 @@
       templateUrl: 'app/theme/inputs/baSwitcher/baSwitcher.html',
       scope: {
         switcherStyle: '@',
-        switcherValue: '='
+        switcherValue: '=',
+        switcherChange: '=',
+        switcherData: '='
       }
     };
   }


### PR DESCRIPTION
Using **`switcher-change`**, you can pass function for ng-change.
This function take data from **`switcher-data`** as first parameter and the second parameter hold the new state of the switcher.