### PR TITLE
Update angular-smart-table version, Fix missing smart-table module issue

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,7 @@
     "angular": "~1.5.8",
     "angular-route": "~1.5.8",
     "angular-slimscroll": "~1.1.5",
-    "angular-smart-table": "~2.1.3",
+    "angular-smart-table": "^2.1.9",
     "angular-toastr": "~2.1.1",
     "angular-touch": "~1.5.8",
     "angular-ui-sortable": "~0.15.0",
@@ -99,6 +99,11 @@
         "fonts/fontawesome-webfont.ttf",
         "fonts/fontawesome-webfont.woff",
         "fonts/fontawesome-webfont.woff2"
+      ]
+    },
+    "angular-smart-table" : {
+      "main": [
+        "dist/smart-table.js"
       ]
     }
   }


### PR DESCRIPTION
Fix for #359 
- Update angular-smart-table version to latest version 2.1.9.
- Fix missing smart-table module issue